### PR TITLE
Matching for wildcards in topics

### DIFF
--- a/src/mqtt-pubsub.ts
+++ b/src/mqtt-pubsub.ts
@@ -144,8 +144,8 @@ export class MQTTPubSub implements PubSubEngine {
   private onMessage(topic: string, message: Buffer) {
     const subscribers = [].concat(
         ...Object.entries(this.subsRefsMap)
-            .filter(([key, value]) => MQTTPubSub.matches(key, topic))
-            .map(([key, value]) => value),
+            .filter(([key]) => MQTTPubSub.matches(key, topic))
+            .map(([_, value]) => value),
     );
 
     // Don't work for nothing..

--- a/src/mqtt-pubsub.ts
+++ b/src/mqtt-pubsub.ts
@@ -38,8 +38,8 @@ export class MQTTPubSub implements PubSubEngine {
     this.subsRefsMap = {};
     this.currentSubscriptionId = 0;
     this.onMQTTSubscribe = options.onMQTTSubscribe || (() => null);
-    this.publishOptionsResolver = options.publishOptions || (() => Promise.resolve({}));
-    this.subscribeOptionsResolver = options.subscribeOptions || (() => Promise.resolve({}));
+    this.publishOptionsResolver = options.publishOptions || (() => Promise.resolve({} as IClientPublishOptions));
+    this.subscribeOptionsResolver = options.subscribeOptions || (() => Promise.resolve({} as IClientSubscribeOptions));
     this.parseMessageWithEncoding = options.parseMessageWithEncoding;
   }
 

--- a/src/mqtt-pubsub.ts
+++ b/src/mqtt-pubsub.ts
@@ -143,9 +143,9 @@ export class MQTTPubSub implements PubSubEngine {
 
   private onMessage(topic: string, message: Buffer) {
     const subscribers = [].concat(
-        ...Object.entries(this.subsRefsMap)
-            .filter(([key]) => MQTTPubSub.matches(key, topic))
-            .map(([_, value]) => value),
+        ...Object.keys(this.subsRefsMap)
+        .filter((key) => MQTTPubSub.matches(key, topic))
+        .map((key) => this.subsRefsMap[key]),
     );
 
     // Don't work for nothing..

--- a/src/pubsub-async-iterator.ts
+++ b/src/pubsub-async-iterator.ts
@@ -32,6 +32,13 @@ import { PubSubEngine } from 'graphql-subscriptions/dist/pubsub-engine';
  */
 export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
 
+  private pullQueue: Function[];
+  private pushQueue: any[];
+  private eventsArray: string[];
+  private allSubscribed: Promise<number[]>;
+  private listening: boolean;
+  private pubsub: PubSubEngine;
+
   constructor(pubsub: PubSubEngine, eventNames: string | string[]) {
     this.pubsub = pubsub;
     this.pullQueue = [];
@@ -59,13 +66,6 @@ export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
   public [$$asyncIterator]() {
     return this;
   }
-
-  private pullQueue: Function[];
-  private pushQueue: any[];
-  private eventsArray: string[];
-  private allSubscribed: Promise<number[]>;
-  private listening: boolean;
-  private pubsub: PubSubEngine;
 
   private async pushValue(event) {
     await this.allSubscribed;

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -489,7 +489,7 @@ describe('Wildcards in subscription topic', function () {
     let messages = [];
     const onMessage = message => {
       try {
-        if (expectedMessages.includes(message)) {
+        if (expectedMessages.indexOf(message) !== -1) {
           if (messages.length === 2) {
             messages.push(message);
             expect(messages).to.deep.equal(expectedMessages);

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -489,7 +489,7 @@ describe('Wildcards in subscription topic', function () {
     let messages = [];
     const onMessage = message => {
       try {
-        if (expectedMessages.indexOf(message) !== -1) {
+        if (expectedMessages.indexOf(message) > -1) {
           if (messages.length === 2) {
             messages.push(message);
             expect(messages).to.deep.equal(expectedMessages);


### PR DESCRIPTION
Hi, @davidyaha. 
I have added a filter to check if any of the subscriptions match the message topic, while matching on wildcards too. Currently on message receive it does not find a key for `topic/a`, if one subscribes for `topic/#` because it only checks if the topic exists as a key in the subscriptions dictionary.

In our use case we would like to allow us to set the topic more generally without specifying the whole path. 

