### PR TITLE
Adds a way to return topic, packet info, and raw buffer data with message

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/davidyaha/graphql-mqtt-subscriptions.git"
+    "url": "https://github.com/henhen724/graphql-mqtt-subscriptions.git"
   },
   "keywords": [
     "graphql",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-mqtt-subscriptions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A graphql-subscriptions PubSub Engine using mqtt protocol",
   "main": "dist/index.js",
   "repository": {
@@ -13,12 +13,12 @@
     "apollo",
     "subscriptions"
   ],
-  "author": "David Yahalomi",
+  "author": "David Yahalomi and Henry Hunt",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/davidyaha/graphql-mqtt-subscriptions/issues"
+    "url": "https://github.com/henhen724/graphql-mqtt-subscriptions/issues"
   },
-  "homepage": "https://github.com/davidyaha/graphql-mqtt-subscriptions",
+  "homepage": "https://github.com/henhen724/graphql-mqtt-subscriptions",
   "scripts": {
     "compile": "tsc --noUnusedParameters --noUnusedLocals",
     "pretest": "npm run compile",
@@ -43,7 +43,7 @@
     "@types/chai-as-promised": "0.0.30",
     "@types/graphql": "^0.9.0",
     "@types/mocha": "^2.2.33",
-    "@types/node": "7.0.18",
+    "@types/node": "^14.14.25",
     "@types/simple-mock": "0.0.27",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
@@ -53,7 +53,7 @@
     "remap-istanbul": "^0.9.5",
     "simple-mock": "^0.7.0",
     "tslint": "^5.2.0",
-    "typescript": "^2.3.4"
+    "typescript": "^4.1.5"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -244,6 +244,33 @@ describe('MQTTPubSub', function () {
 
   });
 
+  it('can subscribe with fullPacketInfo', function (done) {
+    const pubSubPacketInfo = new MQTTPubSub({
+      includeFullPacketInfo: true,
+    });
+
+    let sub;
+    const onMessage = ({ topic, payload, parsedMessage }) => {
+      pubSubPacketInfo.unsubscribe(sub);
+
+      try {
+        expect(topic).to.equals('Posts');
+        expect(payload).not.to.be.an('undefined');
+        expect(parsedMessage).to.equals('test');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    };
+
+    pubSubPacketInfo.subscribe('Posts', onMessage).then(subId => {
+      expect(subId).to.be.a('number');
+      pubSubPacketInfo.publish('Posts', 'test');
+      sub = subId;
+    }).catch(err => done(err));
+
+  });
+
   it('allows to change encodings of messages passed through MQTT broker', function (done) {
     const pubsub = new MQTTPubSub({
       parseMessageWithEncoding: 'base64',

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,9 +24,10 @@
   version "2.2.41"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.41.tgz#e27cf0817153eb9f2713b2d3f6c68f1e1c3ca608"
 
-"@types/node@7.0.18":
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
+"@types/node@^14.14.25":
+  version "14.14.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.25.tgz#15967a7b577ff81383f9b888aa6705d43fbbae93"
+  integrity sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
 
 "@types/simple-mock@0.0.27":
   version "0.0.27"
@@ -1567,9 +1568,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.3.4:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+typescript@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
This is an implementation of my feature request #15.  I see that pull request #14 implements a similar method; however, it does not include the packet info provided by the MQTT library and removes message parsing.